### PR TITLE
Proxy and ECD fallback mechanism

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ task wrapper(type: Wrapper) {
 }
 
 group = 'io.openio.sds'
-version = '0.5.0'
+version = '0.5.1-SNAPSHOT'
 
 dependencies {
 	compile group: 'log4j', name: 'log4j', version: '1.2.17'

--- a/src/main/java/io/openio/sds/ClientBuilder.java
+++ b/src/main/java/io/openio/sds/ClientBuilder.java
@@ -18,7 +18,7 @@ import io.openio.sds.storage.rawx.RawxClient;
  * Builder for @link {@link Client} implementations
  * 
  * @author Christopher Dedeurwaerder
- *
+ * @author Florent Vennetier
  */
 public class ClientBuilder {
 
@@ -39,7 +39,7 @@ public class ClientBuilder {
 		RawxClient rawx = new RawxClient(rawxHttp, settings.rawx());
 		EcdClient ecd = null == settings.proxy().ecd() 
 				? null
-				: new EcdClient(rawxHttp, settings.rawx(), settings.proxy().ecd());
+				: new EcdClient(rawxHttp, settings.rawx(), settings.proxy().allEcdHosts());
 		return new DefaultClient(proxy, rawx, ecd);
 	}
 

--- a/src/main/java/io/openio/sds/Settings.java
+++ b/src/main/java/io/openio/sds/Settings.java
@@ -6,9 +6,11 @@ import io.openio.sds.storage.rawx.RawxSettings;
 /**
  * 
  * @author Christopher Dedeurwaerder
- *
+ * @author Florent Vennetier
  */
 public class Settings {
+
+    public static String MULTI_VALUE_SEPARATOR = ",";
 
     private ProxySettings proxy = new ProxySettings();
     private RawxSettings rawx = new RawxSettings();
@@ -20,7 +22,7 @@ public class Settings {
     public ProxySettings proxy() {
         return proxy;
     }
-    
+
     /**
      * Specifies a proxyd connection configuration
      * @param proxy
@@ -31,7 +33,7 @@ public class Settings {
         this.proxy = proxy;
         return this;
     }
-    
+
     /**
      * Returns rawx services connection configuration
      * @return rawx services connection configuration
@@ -39,7 +41,7 @@ public class Settings {
     public RawxSettings rawx() {
         return rawx;
     }
-    
+
     /**
      * Specifies rawx connections configuration
      * @param rawx the configuration to set
@@ -48,5 +50,5 @@ public class Settings {
     public Settings rawx(RawxSettings rawx) {
         this.rawx = rawx;
         return this;
-    }    
+    }
 }

--- a/src/main/java/io/openio/sds/common/AbstractSocketProvider.java
+++ b/src/main/java/io/openio/sds/common/AbstractSocketProvider.java
@@ -1,0 +1,42 @@
+package io.openio.sds.common;
+
+import static java.lang.String.format;
+import io.openio.sds.exceptions.OioException;
+import io.openio.sds.http.OioHttpSettings;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import static io.openio.sds.common.Check.checkArgument;
+
+/**
+ *
+ * @author Florent Vennetier
+ *
+ */
+public abstract class AbstractSocketProvider implements SocketProvider {
+
+    /**
+     * Configure an already create Socket with provided settings, and establish the connection.
+     *
+     * @param sock A Socket instance
+     * @param target The address to connect the socket to
+     * @param http The settings to apply
+     * @throws OioException
+     */
+    protected void configureAndConnect(Socket sock, InetSocketAddress target, OioHttpSettings http)
+            throws OioException {
+        checkArgument(sock != null, "'sock' argument should not be null");
+        checkArgument(target != null, "'target' argument should not be null");
+        checkArgument(http != null, "'http' argument should not be null");
+        try {
+            sock.setSendBufferSize(http.sendBufferSize());
+            sock.setReuseAddress(true);
+            sock.setReceiveBufferSize(http.receiveBufferSize());
+            sock.setSoTimeout(http.readTimeout());
+            sock.connect(target, http.connectTimeout());
+        } catch (IOException e) {
+            throw new OioException(format("Unable to get connection to %s", target.toString()), e);
+        }
+    }
+}

--- a/src/main/java/io/openio/sds/common/SocketProvider.java
+++ b/src/main/java/io/openio/sds/common/SocketProvider.java
@@ -1,5 +1,6 @@
 package io.openio.sds.common;
 
+import java.net.InetSocketAddress;
 import java.net.Socket;
 
 /**
@@ -10,6 +11,7 @@ import java.net.Socket;
 public interface SocketProvider {
 
     public Socket getSocket(String host, int port);
+    public Socket getSocket(InetSocketAddress addr);
 
     public boolean reusableSocket();
 

--- a/src/main/java/io/openio/sds/common/SocketProviders.java
+++ b/src/main/java/io/openio/sds/common/SocketProviders.java
@@ -1,67 +1,76 @@
 package io.openio.sds.common;
 
-import static java.lang.String.format;
-
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.Socket;
-
-import io.openio.sds.exceptions.OioException;
 import io.openio.sds.http.OioHttpSettings;
 import io.openio.sds.http.SocketPool;
 import io.openio.sds.pool.PoolingSettings;
 
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
 /**
  * 
  * @author Christopher Dedeurwaerder
- *
+ * @author Florent Vennetier
  */
 public class SocketProviders {
 
-	public static SocketProvider pooledSocketProvider(PoolingSettings poolSettings, OioHttpSettings httpSettings,
-			final InetSocketAddress target) {
+    /**
+     * Socket provider that reuses socket instances if possible.
+     *
+     * @param target
+     *            The address that will be requested most of the time. A request
+     *            to another address will create a new socket instead of taking
+     *            it from the pool.
+     */
+    public static SocketProvider pooledSocketProvider(PoolingSettings poolSettings,
+            final OioHttpSettings httpSettings, final InetSocketAddress target) {
 
-		final SocketPool pool = new SocketPool(httpSettings, poolSettings, target);
-		return new SocketProvider() {
+        final SocketPool pool = new SocketPool(httpSettings, poolSettings, target);
+        return new AbstractSocketProvider() {
 
-			@Override
-			public boolean reusableSocket() {
-				return true;
-			}
+            @Override
+            public boolean reusableSocket() {
+                return true;
+            }
 
-			@Override
-			public Socket getSocket(String host, int port) {
-				return pool.lease();
-			}
-		};
-	}
-	
-	public static SocketProvider directSocketProvider(final OioHttpSettings http) {
-		return new SocketProvider() {
+            @Override
+            public Socket getSocket(String host, int port) {
+                return getSocket(new InetSocketAddress(host, port));
+            }
 
-			@Override
-			public boolean reusableSocket() {
-				return false;
-			}
+            @Override
+            public Socket getSocket(InetSocketAddress addr) {
+                if (!addr.equals(target)) {
+                    Socket sock = new Socket();
+                    configureAndConnect(sock, addr, httpSettings);
+                    return sock;
+                } else {
+                    return pool.lease();
+                }
+            }
+        };
+    }
 
-			@Override
-			public Socket getSocket(String host, int port) {
-				 InetSocketAddress target = new InetSocketAddress(host, port);
-	                try {
-	                    Socket sock = new Socket();
-	                    sock.setSendBufferSize(http.sendBufferSize());
-	                    sock.setReuseAddress(true);
-	                    sock.setReceiveBufferSize(http.receiveBufferSize());
-	                    sock.setSoTimeout(http.readTimeout());
-	                    sock.connect(target, http.connectTimeout());
-	                    return sock;
-	                } catch (IOException e) {
-	                    throw new OioException(format(
-	                            "Unable to get connection to %s",
-	                            target.toString()), e);
-	                }
-			}
-		};
-	}
+    public static SocketProvider directSocketProvider(final OioHttpSettings http) {
+        return new AbstractSocketProvider() {
 
+            @Override
+            public boolean reusableSocket() {
+                return false;
+            }
+
+            @Override
+            public Socket getSocket(String host, int port) {
+                InetSocketAddress target = new InetSocketAddress(host, port);
+                return getSocket(target);
+            }
+
+            @Override
+            public Socket getSocket(InetSocketAddress target) {
+                Socket sock = new Socket();
+                configureAndConnect(sock, target, http);
+                return sock;
+            }
+        };
+    }
 }

--- a/src/main/java/io/openio/sds/http/OioHttp.java
+++ b/src/main/java/io/openio/sds/http/OioHttp.java
@@ -337,9 +337,10 @@ public class OioHttp {
 				        .append("=")
 				        .append(h.getValue());
 			}
+			String uriPath = uri.getPath();
 			StringBuilder req = new StringBuilder(method)
 			        .append(" ")
-			        .append(uri.getPath())
+			        .append(uriPath != null && !uriPath.isEmpty()? uriPath : "/")
 			        .append(qbuilder.length() > 0 ? "?" : "")
 			        .append(qbuilder.length() > 0 ? (removeTrailindAnd
 			                ? qbuilder.substring(1) : qbuilder.toString()) : "")

--- a/src/main/java/io/openio/sds/proxy/ProxyClient.java
+++ b/src/main/java/io/openio/sds/proxy/ProxyClient.java
@@ -113,26 +113,12 @@ import io.openio.sds.models.ServiceInfo;
 public class ProxyClient {
     private OioHttp http;
     private ProxySettings settings;
-    private ArrayList<InetSocketAddress> altProxies = null;
-    private static final SdsLogger logger = SdsLoggerFactory
-            .getLogger(ProxyClient.class);
+    private List<InetSocketAddress> altProxies = null;
 
     public ProxyClient(OioHttp http, ProxySettings settings) {
         this.http = http;
         this.settings = settings;
-        List<String> allProxies = this.settings.allUrls();
-        if (allProxies != null && allProxies.size() > 1) {
-            altProxies = new ArrayList<InetSocketAddress>();
-            for (String url: allProxies) {
-                URI proxyUri;
-                try {
-                    proxyUri = new URI(url);
-                    altProxies.add(new InetSocketAddress(proxyUri.getHost(), proxyUri.getPort()));
-                } catch (URISyntaxException e) {
-                    logger.warn("Invalid proxy URL: " + url, e);
-                }
-            }
-        }
+        this.altProxies = this.settings.allHosts();
     }
 
     /* -- CS -- */

--- a/src/main/java/io/openio/sds/proxy/ProxyClient.java
+++ b/src/main/java/io/openio/sds/proxy/ProxyClient.java
@@ -70,6 +70,10 @@ import static java.lang.String.format;
 
 import java.io.InputStreamReader;
 import java.lang.reflect.Type;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -88,6 +92,8 @@ import io.openio.sds.exceptions.OioException;
 import io.openio.sds.exceptions.OioSystemException;
 import io.openio.sds.http.OioHttp;
 import io.openio.sds.http.OioHttpResponse;
+import io.openio.sds.logging.SdsLogger;
+import io.openio.sds.logging.SdsLoggerFactory;
 import io.openio.sds.models.BeansRequest;
 import io.openio.sds.models.ChunkInfo;
 import io.openio.sds.models.ContainerInfo;
@@ -107,10 +113,26 @@ import io.openio.sds.models.ServiceInfo;
 public class ProxyClient {
     private OioHttp http;
     private ProxySettings settings;
+    private ArrayList<InetSocketAddress> altProxies = null;
+    private static final SdsLogger logger = SdsLoggerFactory
+            .getLogger(ProxyClient.class);
 
     public ProxyClient(OioHttp http, ProxySettings settings) {
         this.http = http;
         this.settings = settings;
+        List<String> allProxies = this.settings.allUrls();
+        if (allProxies != null && allProxies.size() > 1) {
+            altProxies = new ArrayList<InetSocketAddress>();
+            for (String url: allProxies) {
+                URI proxyUri;
+                try {
+                    proxyUri = new URI(url);
+                    altProxies.add(new InetSocketAddress(proxyUri.getHost(), proxyUri.getPort()));
+                } catch (URISyntaxException e) {
+                    logger.warn("Invalid proxy URL: " + url, e);
+                }
+            }
+        }
     }
 
     /* -- CS -- */
@@ -123,6 +145,7 @@ public class ProxyClient {
     public NamespaceInfo getNamespaceInfo() throws OioException {
         return http
                 .get(format(CS_NSINFO_FORMAT, settings.url(), settings.ns()))
+                .alternativeHosts(altProxies)
                 .verifier(STANDALONE_VERIFIER).execute(NamespaceInfo.class);
     }
 
@@ -137,8 +160,9 @@ public class ProxyClient {
      */
     public List<ServiceInfo> getServices(String type) throws OioException {
         OioHttpResponse resp = http
-                .get(format(CS_GETSRV_FORMAT, settings.url(), settings.ns(),
-                        type)).verifier(STANDALONE_VERIFIER).execute();
+                .get(format(CS_GETSRV_FORMAT, settings.url(), settings.ns(), type))
+                    .alternativeHosts(altProxies)
+                    .verifier(STANDALONE_VERIFIER).execute();
         return serviceInfoListAndClose(resp);
     }
 
@@ -170,6 +194,7 @@ public class ProxyClient {
         checkArgument(null != url, INVALID_URL_MSG);
         http.post(format(DIR_REF_CREATE_FORMAT, settings.url(), settings.ns(),
                         Strings.urlEncode(url.account()), Strings.urlEncode(url.container())))
+                .alternativeHosts(altProxies)
                 .header(OIO_REQUEST_ID_HEADER, reqId)
                 .verifier(REFERENCE_VERIFIER).execute().close();
     }
@@ -204,6 +229,7 @@ public class ProxyClient {
         return http
                 .get(format(DIR_REF_SHOW_FORMAT, settings.url(), settings.ns(),
                         Strings.urlEncode(url.account()), Strings.urlEncode(url.container())))
+                .alternativeHosts(altProxies)
                 .header(OIO_REQUEST_ID_HEADER, reqId)
                 .verifier(REFERENCE_VERIFIER).execute(ReferenceInfo.class);
     }
@@ -239,6 +265,7 @@ public class ProxyClient {
         http.post(
                 format(DIR_REF_DELETE_FORMAT, settings.url(), settings.ns(),
                         Strings.urlEncode(url.account()), Strings.urlEncode(url.container())))
+                .alternativeHosts(altProxies)
                 .header(OIO_REQUEST_ID_HEADER, reqId)
                 .verifier(REFERENCE_VERIFIER).execute().close();
     }
@@ -279,6 +306,7 @@ public class ProxyClient {
                 .post(format(DIR_LINK_SRV_FORMAT, settings.url(),
                         settings.ns(), 
                         Strings.urlEncode(url.account()), Strings.urlEncode(url.container()), type))
+                .alternativeHosts(altProxies)
                 .header(OIO_REQUEST_ID_HEADER, reqId)
                 .verifier(REFERENCE_VERIFIER).execute();
 
@@ -323,6 +351,7 @@ public class ProxyClient {
         return http
                 .get(format(DIR_LIST_SRV_FORMAT, settings.url(), settings.ns(),
                         Strings.urlEncode(url.account()), Strings.urlEncode(url.container()), type))
+                .alternativeHosts(altProxies)
                 .header(OIO_REQUEST_ID_HEADER, reqId)
                 .verifier(REFERENCE_VERIFIER).execute(ReferenceInfo.class)
                 .srv();
@@ -361,6 +390,7 @@ public class ProxyClient {
         http.post(
                 format(DIR_UNLINK_SRV_FORMAT, settings.url(), settings.ns(),
                         Strings.urlEncode(url.account()), Strings.urlEncode(url.container()), type))
+                .alternativeHosts(altProxies)
                 .header(OIO_REQUEST_ID_HEADER, reqId)
                 .verifier(REFERENCE_VERIFIER).execute().close();
 
@@ -398,6 +428,7 @@ public class ProxyClient {
         OioHttpResponse resp = http
                 .post(format(CREATE_CONTAINER_FORMAT, settings.url(),
                         settings.ns(), Strings.urlEncode(url.account()), Strings.urlEncode(url.container())))
+                .alternativeHosts(altProxies)
                 .header(OIO_ACTION_MODE_HEADER, "autocreate")
                 .header(OIO_REQUEST_ID_HEADER, reqId).body("{}")
                 .verifier(CONTAINER_VERIFIER).execute().close();
@@ -438,6 +469,7 @@ public class ProxyClient {
                 .get(format(GET_CONTAINER_INFO_FORMAT, settings.url(),
                         settings.ns(),
                         Strings.urlEncode(url.account()), Strings.urlEncode(url.container())))
+                .alternativeHosts(altProxies)
                 .header(OIO_REQUEST_ID_HEADER, reqId)
                 .verifier(CONTAINER_VERIFIER).execute().close();
 
@@ -497,13 +529,15 @@ public class ProxyClient {
         return http
                 .get(format(LIST_OBJECTS_FORMAT, settings.url(), settings.ns(),
                         Strings.urlEncode(url.account()), Strings.urlEncode(url.container())))
+                .alternativeHosts(altProxies)
                 .query(MAX_PARAM,
                         options.limit() > 0 ? String.valueOf(options.limit())
                                 : null).query(PREFIX_PARAM, options.prefix())
                 .query(MARKER_PARAM, options.marker())
                 .query(DELIMITER_PARAM, options.delimiter())
                 .header(OIO_REQUEST_ID_HEADER, reqId)
-                .verifier(CONTAINER_VERIFIER).execute(ObjectList.class);
+                .verifier(CONTAINER_VERIFIER)
+                .execute(ObjectList.class);
     }
 
     /**
@@ -535,6 +569,7 @@ public class ProxyClient {
         http.post(
                 format(DELETE_CONTAINER_FORMAT, settings.url(), settings.ns(),
                         Strings.urlEncode(url.account()), Strings.urlEncode(url.container())))
+                .alternativeHosts(altProxies)
                 .verifier(CONTAINER_VERIFIER)
                 .header(OIO_REQUEST_ID_HEADER, reqId).execute().close();
     }
@@ -579,6 +614,7 @@ public class ProxyClient {
                         Strings.urlEncode(url.container()),
                         Strings.urlEncode(url.object())))
                 .body(gson().toJson(new BeansRequest().size(size)))
+                .alternativeHosts(altProxies)
                 .header(ACTION_MODE_HEADER,
                         settings.autocreate() ? OioConstants.AUTOCREATE_ACTION_MODE
                                 : null).header(OIO_REQUEST_ID_HEADER, reqId)
@@ -632,6 +668,7 @@ public class ProxyClient {
                 .header(CONTENT_META_CHUNK_METHOD_HEADER, oinf.chunkMethod())
                 .header(CONTENT_META_VERSION_HEADER,
                         versionHeader(oinf, version)).body(body)
+                .alternativeHosts(altProxies)
                 .verifier(OBJECT_VERIFIER).execute().close();
         return oinf;
     }
@@ -684,6 +721,7 @@ public class ProxyClient {
                 .header(OIO_REQUEST_ID_HEADER, reqId)
                 .header(CONTENT_META_VERSION_HEADER,
                         null == version ? null : version.toString())
+                .alternativeHosts(altProxies)
                 .verifier(OBJECT_VERIFIER).execute();
         ObjectInfo info = objectShowObjectInfoAndClose(url, resp);
         info.properties(getObjectProperties(url, reqId));
@@ -741,6 +779,7 @@ public class ProxyClient {
                 .header(CONTENT_META_VERSION_HEADER,
                         null == version ? null : version.toString())
                 .header(OIO_REQUEST_ID_HEADER, reqId).verifier(OBJECT_VERIFIER)
+                .alternativeHosts(altProxies)
                 .execute().close();
     }
 
@@ -794,6 +833,7 @@ public class ProxyClient {
                         Strings.urlEncode(url.account()),
                         Strings.urlEncode(url.container())))
                 .header(OIO_REQUEST_ID_HEADER, reqId)
+                .alternativeHosts(altProxies)
                 .verifier(CONTAINER_VERIFIER).body(root).execute().close();
     }
 
@@ -834,6 +874,7 @@ public class ProxyClient {
                         Strings.urlEncode(url.account()),
                         Strings.urlEncode(url.container())))
                 .header(OIO_REQUEST_ID_HEADER, reqId)
+                .alternativeHosts(altProxies)
                 .verifier(CONTAINER_VERIFIER).execute();
         try {
             Map<String, Map<String, String>> res = JsonUtils.jsonToMapMap(resp
@@ -885,6 +926,7 @@ public class ProxyClient {
                         Strings.urlEncode(url.account()),
                         Strings.urlEncode(url.container())))
                 .header(OIO_REQUEST_ID_HEADER, reqId).body(gson().toJson(keys))
+                .alternativeHosts(altProxies)
                 .verifier(CONTAINER_VERIFIER).execute().close();
     }
 
@@ -927,6 +969,7 @@ public class ProxyClient {
                         Strings.urlEncode(url.account()),
                         Strings.urlEncode(url.container())))
                 .header(OIO_REQUEST_ID_HEADER, reqId).body(gson().toJson(keys))
+                .alternativeHosts(altProxies)
                 .verifier(CONTAINER_VERIFIER).execute().close();
     }
 
@@ -981,6 +1024,7 @@ public class ProxyClient {
                         Strings.urlEncode(url.container()),
                         Strings.urlEncode(url.object())))
                 .header(OIO_REQUEST_ID_HEADER, reqId).verifier(OBJECT_VERIFIER)
+                .alternativeHosts(altProxies)
                 .body(body).execute().close();
     }
 
@@ -1025,6 +1069,7 @@ public class ProxyClient {
                         Strings.urlEncode(url.account()),
                         Strings.urlEncode(url.container()),
                         Strings.urlEncode(url.object())))
+                .alternativeHosts(altProxies)
                 .header(OIO_REQUEST_ID_HEADER, reqId).verifier(OBJECT_VERIFIER)
                 .execute();
         try {
@@ -1078,6 +1123,7 @@ public class ProxyClient {
                         Strings.urlEncode(url.account()),
                         Strings.urlEncode(url.container()),
                         Strings.urlEncode(url.object())))
+                .alternativeHosts(altProxies)
                 .header(OIO_REQUEST_ID_HEADER, reqId).body(gson().toJson(keys))
                 .verifier(CONTAINER_VERIFIER).execute().close();
     }
@@ -1125,6 +1171,7 @@ public class ProxyClient {
                         Strings.urlEncode(url.account()),
                         Strings.urlEncode(url.container()),
                         Strings.urlEncode(url.object())))
+                .alternativeHosts(altProxies)
                 .header(OIO_REQUEST_ID_HEADER, reqId).body(gson().toJson(keys))
                 .verifier(CONTAINER_VERIFIER).execute().close();
     }

--- a/src/main/java/io/openio/sds/proxy/ProxySettings.java
+++ b/src/main/java/io/openio/sds/proxy/ProxySettings.java
@@ -1,18 +1,23 @@
 package io.openio.sds.proxy;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import io.openio.sds.Settings;
 import io.openio.sds.http.OioHttpSettings;
 import io.openio.sds.pool.PoolingSettings;
 
 /**
  * 
  * @author Christopher Dedeurwaerder
- *
+ * @author Florent Vennetier
  */
 public class ProxySettings {
 
-    private String url;
     private String ns;
-    private String ecd;
+    private ArrayList<String> urls = new ArrayList<String>();
+    private ArrayList<String> ecds = new ArrayList<String>();
     private boolean ecdrain = true; //not configurable atm cuz we can't do somehow else
     private boolean autocreate = true;
     private OioHttpSettings http = new OioHttpSettings();
@@ -21,13 +26,28 @@ public class ProxySettings {
     public ProxySettings() {
     }
 
+    /**
+     * @return The first proxy URL
+     */
     public String url() {
-        return url;
+        return urls.get(0);
     }
 
-    public ProxySettings url(String url) {
-        this.url = url;
+    public ProxySettings url(String urlv) {
+        for (String url: urlv.split(Settings.MULTI_VALUE_SEPARATOR)) {
+            if (!url.contains("://"))
+                this.urls.add("http://" + url);
+            else
+                this.urls.add(url);
+        }
         return this;
+    }
+
+    /**
+     * @return a read-only list of all known proxy URLs
+     */
+    public List<String> allUrls() {
+        return Collections.unmodifiableList(this.urls);
     }
 
     public String ns() {
@@ -57,25 +77,39 @@ public class ProxySettings {
         return this;
     }
 
+    /**
+     * @return the first ECD URL
+     */
     public String ecd() {
-        return ecd;
+        return ecds.get(0);
     }
 
-    public ProxySettings ecd(String ecd) {
-        this.ecd = ecd;
+    public ProxySettings ecd(String ecdv) {
+        for (String url: ecdv.split(Settings.MULTI_VALUE_SEPARATOR))
+            if (!url.contains("://"))
+                this.ecds.add("http://" + url);
+            else
+                this.ecds.add(url);
         return this;
     }
-    
+
+    /**
+     * @return a read-only list of all known ECD URLs
+     */
+    public List<String> allEcds() {
+        return Collections.unmodifiableList(this.ecds);
+    }
+
     public boolean ecdrain(){
         return ecdrain;
     }
 
-	public boolean autocreate() {
-		return autocreate;
-	}
+    public boolean autocreate() {
+        return autocreate;
+    }
 
-	public ProxySettings autocreate(boolean autocreate) {
-		this.autocreate = autocreate;
-		return this;
-	}
+    public ProxySettings autocreate(boolean autocreate) {
+        this.autocreate = autocreate;
+        return this;
+    }
 }

--- a/src/main/java/io/openio/sds/storage/ecd/EcdInputStream.java
+++ b/src/main/java/io/openio/sds/storage/ecd/EcdInputStream.java
@@ -5,6 +5,7 @@ import static io.openio.sds.http.Verifiers.RAWX_VERIFIER;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.InetSocketAddress;
 import java.util.List;
 
 import io.openio.sds.common.OioConstants;
@@ -34,6 +35,7 @@ public class EcdInputStream extends InputStream {
 	private OioHttpResponse current;
 	private String reqId;
 	private String ecdUrl;
+	private List<InetSocketAddress> ecdHosts = null;
 	private String chunkMethod;
 	private boolean eof = false;
 
@@ -47,6 +49,11 @@ public class EcdInputStream extends InputStream {
 		this.http = http;
 		this.chunkMethod = chunkMethod;
 		this.reqId = reqId;
+	}
+
+	public EcdInputStream alternativeHosts(List<InetSocketAddress> hosts) {
+	    this.ecdHosts = hosts;
+	    return this;
 	}
 
 	@Override
@@ -106,7 +113,8 @@ public class EcdInputStream extends InputStream {
 			        .header(OIO_REQUEST_ID_HEADER, reqId)
 			        .header(OioConstants.CHUNK_META_CONTENT_CHUNK_METHOD,
 			                chunkMethod)
-			        .verifier(RAWX_VERIFIER);
+			        .verifier(RAWX_VERIFIER)
+			        .alternativeHosts(ecdHosts);
 			for (ChunkInfo ci : targets.get(pos).getChunk()) {
 				builder.header(
 				        OioConstants.CHUNK_META_CHUNK_PREFIX + ci.pos().sub(),

--- a/src/main/java/io/openio/sds/storage/rawx/RawxClient.java
+++ b/src/main/java/io/openio/sds/storage/rawx/RawxClient.java
@@ -31,6 +31,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -223,91 +224,108 @@ public class RawxClient implements StorageClient {
 
 	/* --- INTERNALS --- */
 
-	private ObjectInfo uploadPosition(final ObjectInfo oinf,
-	        final int pos, final Long size, InputStream data,
-	        final String reqId) {
-		List<ChunkInfo> cil = oinf.sortedChunks().get(pos);
-		final List<FeedableInputStream> gens = size == 0 ? null
-		        : feedableBodys(cil.size(), size);
-		List<Future<OioException>> futures = new ArrayList<Future<OioException>>();
-		for (int i = 0; i < cil.size(); i++) {
-			final ChunkInfo ci = cil.get(i);
-			final FeedableInputStream in = null == gens ? null : gens.get(i);
+    private ObjectInfo uploadPosition(final ObjectInfo oinf, final int pos, final Long size,
+            InputStream data, final String reqId) {
+        List<ChunkInfo> cil = oinf.sortedChunks().get(pos);
+        final List<FeedableInputStream> gens = size == 0 ? null : feedableBodys(cil.size(), size);
+        List<Future<OioException>> futures = new ArrayList<Future<OioException>>();
+        for (int i = 0; i < cil.size(); i++) {
+            final ChunkInfo ci = cil.get(i);
+            final FeedableInputStream in = null == gens ? null : gens.get(i);
 
-			futures.add(executors.submit(new Callable<OioException>() {
+            Callable<OioException> uploader = new Callable<OioException>() {
 
-				@Override
-				public OioException call() {
-					try {
-						RequestBuilder builder = http.put(ci.url())
-			                    .header(CHUNK_META_CONTAINER_ID,
-			                            oinf.url().cid())
-			                    .header(CHUNK_META_CONTENT_ID, oinf.oid())
-			                    .header(CHUNK_META_CONTENT_VERSION,
-			                            String.valueOf(oinf.version()))
-			                    .header(CHUNK_META_CONTENT_POLICY,
-			                            oinf.policy())
-			                    .header(CHUNK_META_CONTENT_MIME_TYPE,
-			                            oinf.mtype())
-			                    .header(CHUNK_META_CONTENT_CHUNK_METHOD,
-			                            oinf.chunkMethod())
-			                    .header(CHUNK_META_CONTENT_CHUNKSNB,
-			                            String.valueOf(oinf.nbchunks()))
-			                    .header(CHUNK_META_CONTENT_SIZE,
-			                            String.valueOf(oinf.size()))
-			                    .header(CHUNK_META_CONTENT_PATH,
-			                            oinf.url().object())
-			                    .header(CHUNK_META_CHUNK_ID, ci.id())
-			                    .header(CHUNK_META_CHUNK_POS,
-			                            ci.pos().toString())
-			                    .header(OIO_REQUEST_ID_HEADER, reqId)
-			                    .verifier(RAWX_VERIFIER);
-						if (null == gens)
-							builder.body("");
-						else
-							builder.body(in, size);
-						ci.size(size);
-						ci.hash(builder.execute()
-			                    .close(false)
-			                    .header(CHUNK_META_CHUNK_HASH));
-					} catch (OioException e) {
-						return e;
-					}
-					return null;
-				}
-			}));
-		}
-		consume(data, size, gens, futures);
-		try {
-			ArrayList<OioException> failures = new ArrayList<OioException>();
-			for (Future<OioException> f : futures) {
-				OioException e;
-				try {
-					e = f.get(60, TimeUnit.SECONDS);
-				} catch (TimeoutException e1) {
-					e = new OioException("Chunk upload timeout", e1);
-				}
-				// TODO: log the URL of the chunk that failed
-				if (null != e) {
-					logger.warn("Failed to upload chunk", e);
-					failures.add(e);
-				}
-			}
-			if (failures.size() >= cil.size()) {
-				throw new OioException("All chunk uploads failed",
-				        failures.get(0));
-			} else if (failures.size() > 0) {
-				logger.warn(String
-				        .format("%1$d of %2$d uploads failed for position %3$d of %4$s",
-				                failures.size(), cil.size(), pos, oinf.url()));
-			}
-		} catch (InterruptedException e) {
-			throw new OioException("got interrupted", e);
-		} catch (ExecutionException e) {
-			throw new OioException("Execution exception", e.getCause());
-		}
-		return oinf;
-	}
+                @Override
+                public OioException call() {
+                    try {
+                        RequestBuilder builder = http
+                                .put(ci.url())
+                                .header(CHUNK_META_CONTAINER_ID, oinf.url().cid())
+                                .header(CHUNK_META_CONTENT_ID, oinf.oid())
+                                .header(CHUNK_META_CONTENT_VERSION, String.valueOf(oinf.version()))
+                                .header(CHUNK_META_CONTENT_POLICY, oinf.policy())
+                                .header(CHUNK_META_CONTENT_MIME_TYPE, oinf.mtype())
+                                .header(CHUNK_META_CONTENT_CHUNK_METHOD, oinf.chunkMethod())
+                                .header(CHUNK_META_CONTENT_CHUNKSNB,
+                                        String.valueOf(oinf.nbchunks()))
+                                .header(CHUNK_META_CONTENT_SIZE, String.valueOf(oinf.size()))
+                                .header(CHUNK_META_CONTENT_PATH, oinf.url().object())
+                                .header(CHUNK_META_CHUNK_ID, ci.id())
+                                .header(CHUNK_META_CHUNK_POS, ci.pos().toString())
+                                .header(OIO_REQUEST_ID_HEADER, reqId).verifier(RAWX_VERIFIER);
+                        if (null == gens)
+                            builder.body("");
+                        else
+                            builder.body(in, size);
+                        ci.size(size);
+                        ci.hash(builder.execute().close(false).header(CHUNK_META_CHUNK_HASH));
+                    } catch (OioException e) {
+                        return e;
+                    }
+                    return null;
+                }
+            };
+            int retry = 0;
+            try {
+                while (true) {
+                    try {
+                        Future<OioException> upload = executors.submit(uploader);
+                        futures.add(upload);
+                        break;
+                    } catch (RejectedExecutionException ree) {
+                        if (retry < 5) {
+                            int delay = 1 << retry;
+                            logger.warn("Failed to start rawx upload, retry in " + delay + "s",
+                                    ree);
+                            try {
+                                Thread.sleep(delay * 1000);
+                            } catch (InterruptedException e) {
+                                throw new OioException("Failed to retry rawx upload", e);
+                            }
+                        } else {
+                            throw new OioException("Failed to schedule rawx upload", ree);
+                        }
+                        retry++;
+                    }
+                }
+            } catch (RuntimeException e) {
+                try {
+                    in.close();
+                } catch (IOException e1) {
+                    logger.warn(e1);
+                }
+                throw e;
+            }
+        }
+        consume(data, size, gens, futures);
+        try {
+            ArrayList<OioException> failures = new ArrayList<OioException>();
+            for (Future<OioException> f : futures) {
+                OioException e;
+                try {
+                    e = f.get(60, TimeUnit.SECONDS);
+                } catch (TimeoutException e1) {
+                    e = new OioException("Chunk upload timeout", e1);
+                }
+                // TODO: log the URL of the chunk that failed
+                if (null != e) {
+                    logger.warn("Failed to upload chunk", e);
+                    failures.add(e);
+                }
+            }
+            if (failures.size() >= cil.size()) {
+                throw new OioException("All chunk uploads failed", failures.get(0));
+            } else if (failures.size() > 0) {
+                logger.warn(String.format("%1$d of %2$d uploads failed for position %3$d of %4$s",
+                        failures.size(), cil.size(), pos, oinf.url()));
+            }
+        } catch (InterruptedException e) {
+            throw new OioException("got interrupted", e);
+        } catch (ExecutionException e) {
+            throw new OioException("Execution exception", e.getCause());
+        }
+        return oinf;
+    }
 
 	private void consume(InputStream data, Long size,
 	        List<FeedableInputStream> gens,

--- a/src/test/java/io/openio/sds/ProxyClientTest.java
+++ b/src/test/java/io/openio/sds/ProxyClientTest.java
@@ -1,9 +1,12 @@
 package io.openio.sds;
 
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
-
 
 import io.openio.sds.http.OioHttp;
 import io.openio.sds.http.OioHttp.RequestBuilder;
@@ -57,6 +60,8 @@ public class ProxyClientTest {
                 .thenReturn(mockedBuilder);
         Mockito.when(mockedBuilder.execute((Class<ObjectList>) Mockito.any()))
                 .thenReturn(mockedList);
+        Mockito.when(mockedBuilder.alternativeHosts((List<InetSocketAddress>)Mockito.any()))
+                .thenReturn(mockedBuilder);
 
         OioHttp mockedHttp = Mockito.mock(OioHttp.class);
         Mockito.when(mockedHttp.get(Mockito.anyString()))

--- a/src/test/java/io/openio/sds/TestHelper.java
+++ b/src/test/java/io/openio/sds/TestHelper.java
@@ -38,7 +38,6 @@ public class TestHelper {
     public static String proxyd() {
         if (!isLoaded)
             loadConfiguration();
-        System.out.println("proxy: " + rawProxyString);
         return rawProxyString;
     }
 

--- a/src/test/java/io/openio/sds/storage/ecd/EcdClientTest.java
+++ b/src/test/java/io/openio/sds/storage/ecd/EcdClientTest.java
@@ -27,22 +27,23 @@ import io.openio.sds.models.ECInfo;
 import io.openio.sds.models.ObjectInfo;
 import io.openio.sds.models.OioUrl;
 import io.openio.sds.models.Position;
+import io.openio.sds.proxy.ProxySettings;
 import io.openio.sds.storage.rawx.RawxSettings;
 
 public class EcdClientTest {
 
-	private static FakeEcd ecd;
-	private static String ecdUrl = "http://127.0.0.1:6789/";
+	private static FakeEcd fakeEcd;
+	private static String fakeEcdUrl = "http://127.0.0.1:6789/";
 
 	@BeforeClass
 	public static void setup() throws Exception {
-		ecd = new FakeEcd(6789);
-		ecd.start();
+		fakeEcd = new FakeEcd(6789);
+		fakeEcd.start();
 	}
 
 	@AfterClass
 	public static void teardown() throws Exception {
-		ecd.stop();
+		fakeEcd.stop();
 	}
 
 	@Test
@@ -53,7 +54,8 @@ public class EcdClientTest {
 		OioHttp http = OioHttp.http(new OioHttpSettings(),
 		        SocketProviders.directSocketProvider(new OioHttpSettings()));
 
-		EcdClient client = new EcdClient(http, new RawxSettings(), ecdUrl);
+		EcdClient client = new EcdClient(http, new RawxSettings(),
+		        new ProxySettings().ecd(fakeEcdUrl).allEcdHosts());
 
 		byte[] data = TestHelper.bytes(size);
 
@@ -96,7 +98,7 @@ public class EcdClientTest {
 
 		client.uploadChunks(mockedObject, data);
 
-		byte[] uploaded = ecd.getLastData();
+		byte[] uploaded = fakeEcd.getLastData();
 
 		Assert.assertEquals(data.length, uploaded.length);
 
@@ -110,13 +112,13 @@ public class EcdClientTest {
 	public void testRoundtrip() throws IOException {
 
 		Long size = 10 * 1000 * 1024L;
-		String realEcdUrl = "http://127.0.0.1:6001/";
 		String chunkMethod = "ec/algo=liberasurecode_rs_vand,k=6,m=3";
 
 		OioHttp http = OioHttp.http(new OioHttpSettings(),
 				SocketProviders.directSocketProvider(new OioHttpSettings()));
 
-		EcdClient client = new EcdClient(http, new RawxSettings(), realEcdUrl);
+		EcdClient client = new EcdClient(http, new RawxSettings(),
+		        new ProxySettings().ecd(TestHelper.ecd()).allEcdHosts());
 
 		byte[] dataIn = TestHelper.bytes(size);
 


### PR DESCRIPTION
Implement a simple fallback mechanism for proxy and ECD services. When encountering an IO error, the client will try the next proxy (or ECD) URL, and so on. You just need to pass a comma-separated list of URLs to the [ProxySettings#url(String)](https://github.com/open-io/oio-api-java/blob/0.5.0/src/main/java/io/openio/sds/proxy/ProxySettings.java#L28) and [ProxySettings#ecd(String)](https://github.com/open-io/oio-api-java/blob/0.5.0/src/main/java/io/openio/sds/proxy/ProxySettings.java#L64) functions.

Fix #25 
Close #24 
