### PR TITLE
Support service IDs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
     - TEST_SUITE=3COPIES-11RAWX
     - TEST_SUITE=3COPIES-11RAWX SDS_BRANCH=4.1.x
     - TEST_SUITE=3COPIES-11RAWX SDS_BRANCH=4.2.x
+    - TEST_SUITE=3COPIES-11RAWX SDS_BRANCH=4.2.x OPTS=-U
 script:
   - set -e
   - mkdir /tmp/oio
@@ -31,7 +32,7 @@ script:
   - python setup.py install
   - export G_DEBUG_LEVEL=D PATH="$PATH:/tmp/oio/bin" LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/tmp/oio/lib"
   - export OIO_NS="NS-${RANDOM}" OIO_ACCOUNT="ACCT-$RANDOM" OIO_USER=USER-$RANDOM OIO_PATH=PATH-$RANDOM
-  - test -f etc/bootstrap-preset-${TEST_SUITE}.yml && oio-reset.sh -v -v -N $OIO_NS -f etc/bootstrap-preset-${TEST_SUITE}.yml || oio-reset.sh -v -v -N $OIO_NS -f etc/bootstrap-${TEST_SUITE}.yml
+  - oio-reset.sh -v -v $OPTS -N $OIO_NS -f etc/bootstrap-preset-${TEST_SUITE}.yml
   - cd .. && ./gradlew test
   - ./gradlew assemble
 after_success:

--- a/src/main/java/io/openio/sds/models/ChunkInfo.java
+++ b/src/main/java/io/openio/sds/models/ChunkInfo.java
@@ -8,6 +8,7 @@ public class ChunkInfo {
     }
 
     private String url;
+    private String real_url;
     private Long size;
     private String hash;
     private Position pos;
@@ -33,6 +34,11 @@ public class ChunkInfo {
         return this;
     }
 
+    public ChunkInfo real_url(String real_url) {
+        this.real_url = real_url;
+        return this;
+    }
+
     public ChunkInfo size(Long size) {
         this.size = size;
         return this;
@@ -47,9 +53,16 @@ public class ChunkInfo {
         this.pos = pos;
         return this;
     }
-    
+
     public String id(){
         return url.substring(url.lastIndexOf("/") + 1);
+    }
+
+    public String finalUrl() {
+        if (real_url != null && real_url.length() > 0) {
+            return real_url;
+        }
+        return url;
     }
 
     @Override
@@ -57,6 +70,7 @@ public class ChunkInfo {
         return MoreObjects.toStringHelper(this)
                 .omitNullValues()
                 .add("url", url)
+                .add("real_url", real_url)
                 .add("size", size)
                 .add("hash", hash)
                 .add("pos", pos)

--- a/src/main/java/io/openio/sds/storage/ecd/EcdClient.java
+++ b/src/main/java/io/openio/sds/storage/ecd/EcdClient.java
@@ -183,7 +183,7 @@ public class EcdClient implements StorageClient {
 		for (ChunkInfo ci : oinf.sortedChunks().get(pos)) {
 			builder.header(
 			        OioConstants.CHUNK_META_CHUNK_PREFIX + ci.pos().sub(),
-			        ci.url());
+			        ci.finalUrl());
 		}
 
 		// TODO chunks hash

--- a/src/main/java/io/openio/sds/storage/ecd/EcdInputStream.java
+++ b/src/main/java/io/openio/sds/storage/ecd/EcdInputStream.java
@@ -119,7 +119,7 @@ public class EcdInputStream extends InputStream {
 			for (ChunkInfo ci : targets.get(pos).getChunk()) {
 				builder.header(
 				        OioConstants.CHUNK_META_CHUNK_PREFIX + ci.pos().sub(),
-				        ci.url());
+				        ci.finalUrl());
 			}
 
 			builder.header(OioConstants.CHUNK_META_CHUNK_SIZE,

--- a/src/main/java/io/openio/sds/storage/rawx/ObjectInputStream.java
+++ b/src/main/java/io/openio/sds/storage/rawx/ObjectInputStream.java
@@ -109,9 +109,9 @@ public class ObjectInputStream extends InputStream {
 		Target t = targets.get(pos);
 		currentChunk = t.getChunk().get(offset);
 		if (logger.isDebugEnabled())
-			logger.debug("download from " + currentChunk.url());
+			logger.debug("download from " + currentChunk.finalUrl());
 		try {
-			RequestBuilder builder = http.get(currentChunk.url())
+			RequestBuilder builder = http.get(currentChunk.finalUrl())
 					.verifier(RAWX_VERIFIER)
 					.withRequestContext(this.reqCtx);
 

--- a/src/main/java/io/openio/sds/storage/rawx/RawxClient.java
+++ b/src/main/java/io/openio/sds/storage/rawx/RawxClient.java
@@ -207,7 +207,7 @@ public class RawxClient implements StorageClient {
 	public void deleteChunk(ChunkInfo ci) {
 		// no verifier, suppress exceptions
 		try {
-			http.delete(ci.url())
+			http.delete(ci.finalUrl())
 					.execute()
 					.close();
 		} catch (OioException e) {
@@ -234,7 +234,7 @@ public class RawxClient implements StorageClient {
 					UploadResult result = new UploadResult(ci);
 					try {
 						RequestBuilder builder = http
-								.put(ci.url())
+								.put(ci.finalUrl())
 								.header(CHUNK_META_CONTAINER_ID, oinf.url().cid())
 								.header(CHUNK_META_CONTENT_ID, oinf.oid())
 								.header(CHUNK_META_CONTENT_VERSION, String.valueOf(oinf.version()))


### PR DESCRIPTION
Like C API or Python API, the Java Api will now use `url` as chunk_id but use `real_url` when storing chunks.
There is the fallback to `url` if `real_url` is missing, when using previous version of SDS.  